### PR TITLE
End to end test (#22)

### DIFF
--- a/fbo.py
+++ b/fbo.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import os
 import logging
-from utils import fbo_nightly_scraper as fbo, get_fbo_attachments
+from utils import fbo_nightly_scraper, get_fbo_attachments
 from utils.predict import Predict 
 from utils.db.db_utils import get_db_url, session_scope, DataAccessLayer, insert_updated_nightly_file
 
@@ -17,7 +17,7 @@ dal.connect()
 def get_nightly_data(notice_types, naics):
     now = datetime.datetime.now() - datetime.timedelta(1)
     current_date = now.strftime("%Y%m%d")
-    nfbo = fbo.NightlyFBONotices(date = current_date, notice_types = notice_types, naics = naics)
+    nfbo = fbo_nightly_scraper.NightlyFBONotices(date = current_date, notice_types = notice_types, naics = naics)
     file_lines = nfbo.download_from_ftp()
     if not file_lines:
         #exit program if download_from_ftp() failed

--- a/test.py
+++ b/test.py
@@ -9,6 +9,7 @@ from docx import Document
 from bs4 import BeautifulSoup
 import requests
 import httpretty
+from fbo import main
 from utils.db.db import Notice, NoticeType, Attachment, Model
 from utils.db.db_utils import get_db_url, session_scope, insert_updated_nightly_file, DataAccessLayer, clear_data
 from utils.db.db_utils import fetch_notice_type_id, insert_model, insert_notice_types, retrain_check, get_validation_count, get_trained_amount

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch, Mock
 import os
 from utils.fbo_nightly_scraper import NightlyFBONotices
 from fixtures import nightly_file, json_str, filtered_json_str, nightly_data, updated_nightly_data
@@ -599,10 +600,10 @@ class EndToEndTest(unittest.TestCase):
         self.dal = None
         self.main = None
     
-    @unittest.mock.patch('fbo.datetime')
+    @patch('fbo.datetime')
     def test_main(self, datetime_mock):
         # use 10/29 since the 28th's file is only 325 kB
-        datetime_mock.datetime.now = unittest.mock.Mock(return_value=datetime.strptime('Oct 29 2018', '%b %d %Y'))
+        datetime_mock.datetime.now = Mock(return_value=datetime.strptime('Oct 29 2018', '%b %d %Y'))
         self.main()
         self.assertTrue(True)
 

--- a/test.py
+++ b/test.py
@@ -587,6 +587,24 @@ class PostgresTestCase(unittest.TestCase):
             expected = 0
             self.assertEqual(result, expected)
 
+class EndToEndTest(unittest.TestCase):
+    def setUp(self):
+        conn_string = get_db_url()
+        self.dal = DataAccessLayer(conn_string)
+        self.dal.connect()
+        self.main = main
+
+    def tearDown(self):
+        self.dal = None
+        self.main = None
+    
+    @unittest.mock.patch('fbo.datetime')
+    def test_main(self, datetime_mock):
+        # use 10/29 since the 28th's file is only 325 kB
+        datetime_mock.datetime.now = unittest.mock.Mock(return_value=datetime.strptime('Oct 29 2018', '%b %d %Y'))
+        self.main()
+        self.assertTrue(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -601,10 +601,11 @@ class EndToEndTest(unittest.TestCase):
         self.dal = None
         self.main = None
     
-    @patch('fbo.datetime')
-    def test_main(self, datetime_mock):
-        # use 10/29 since the 28th's file is only 325 kB
-        datetime_mock.datetime.now = Mock(return_value=datetime.strptime('Oct 29 2018', '%b %d %Y'))
+    @patch('utils.fbo_nightly_scraper')
+    def test_main(self, fbo_mock):
+        nfbo = fbo_mock.NightlyFBONotices.return_value
+        # use 10/28 since the 28th's file is only 325 kB
+        nfbo.ftp_url = 'ftp://ftp.fbo.gov/FBOFeed20181028'
         self.main()
         self.assertTrue(True)
 

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, Mock
 import os
+from datetime import datetime
 from utils.fbo_nightly_scraper import NightlyFBONotices
 from fixtures import nightly_file, json_str, filtered_json_str, nightly_data, updated_nightly_data
 from utils.get_fbo_attachments import FboAttachments


### PR DESCRIPTION
Add an end-to-end test using [real data](ftp://ftp.fbo.gov/FBOFeed20181028) (it's only about 325 kB). The test merely ensures that `main()` from `fbo.py` is called without raising any exceptions.