### PR TITLE
FIX: Ignore charmap decoding errors when textracting (#106)

### DIFF
--- a/utils/get_fbo_attachments.py
+++ b/utils/get_fbo_attachments.py
@@ -68,13 +68,13 @@ class FboAttachments():
             text (str): a string representing the text of the file.
         '''
         try:
-            b_text = process(file_name)
+            b_text = process(file_name, encoding='utf-8', errors = 'ignore')
         except Exception as e:
             logging.error(f"Exception occurred textracting {file_name} from {url}:  \
-                             {e}", exc_info=True)
+                            {e}", exc_info=True)
             b_text = None
         if b_text:
-            text = b_text.decode('utf-8', errors='ignore')
+            text = b_text.decode('utf8', errors = 'ignore')
         else:
             text = ''
         text = text.strip()


### PR DESCRIPTION
Textract's default string decoding error handler was  'strict', meaning that encoding errors raise a UnicodeError. Switch to ignore, which will just replace the troublesome bytes with empty strings and allow the rest of the document to be processed.