### PR TITLE
FIX: ignore textract decoding errors

### DIFF
--- a/utils/get_fbo_attachments.py
+++ b/utils/get_fbo_attachments.py
@@ -70,6 +70,8 @@ class FboAttachments():
         '''
         try:
             b_text = process(file_name, encoding='utf-8', errors = 'ignore')
+        #TypeError is raised when None is passed to str.decode()
+        #This happens when textract can't extract text from scanned documents
         except TypeError:
             b_text = None
         except Exception as e:

--- a/utils/get_fbo_attachments.py
+++ b/utils/get_fbo_attachments.py
@@ -70,6 +70,8 @@ class FboAttachments():
         '''
         try:
             b_text = process(file_name, encoding='utf-8', errors = 'ignore')
+        except TypeError:
+            b_text = None
         except Exception as e:
             logger.error(f"Exception occurred textracting {file_name} from {url}:  \
                             {e}", exc_info=True)


### PR DESCRIPTION
textract raises a typerror when it encounters documents that it cannot extract any text from (e.g. scanned pds). Instead of logging this error, we'll ignore it explicitly and only log other errors. 